### PR TITLE
Setup GitHub Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,7 +3,6 @@ name: github pages
 on:
   push:
     branches:
-      - setup-gh-pages
       - master
 
 jobs:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,29 @@
+name: github pages
+
+on:
+  push:
+    branches:
+      - setup-gh-pages
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+      - name: Prepare
+        run: ./scripts/prepare-gh-pages
+      - name: Build
+        run: go run ./cmd/ssg --config gh-pages/config.json
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: gh-pages/public
+          publish_branch: gh-pages

--- a/gh-pages/config.json
+++ b/gh-pages/config.json
@@ -1,0 +1,6 @@
+{
+    "author": "klingtnet",
+    "base_url": "https://klingtnet.github.io/static-site-generator",
+    "content_dir": "gh-pages/content",
+    "output_dir": "gh-pages/public"
+}

--- a/scripts/prepare-gh-pages
+++ b/scripts/prepare-gh-pages
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mkdir -p gh-pages/public gh-pages/content
+
+cat <<HEREDOC>gh-pages/content/index.md
+\`\`\`json
+{
+	"author": "klingtnet",
+	"created_at": "2021-09-13"
+}
+\`\`\`
+HEREDOC
+
+cat README.md >>gh-pages/content/index.md


### PR DESCRIPTION
This will generate a single file site using REAMDE.md as the root index file.

The setup-gh-pages branch will be removed from the list of gh-pages
branches after this gets merged.

Note that the source branch for the website must be configured in:
https://github.com/klingtnet/static-site-generator/settings/pages

Documentation about GitHub Pages can be found here:
https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages